### PR TITLE
fix: add a port check while parsing `Origin`

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -96,7 +96,7 @@ func CORS(options ...Options) flamego.Handler {
 			var ok bool
 			for _, d := range opt.AllowDomain {
 				if u.Host == d ||
-					(opt.AllowSubdomain && strings.HasSuffix(u.Hostname(), "."+d)) ||
+					(opt.AllowSubdomain && strings.HasSuffix(u.Host, "."+d)) ||
 					d == "!*" {
 					ok = true
 					break

--- a/cors.go
+++ b/cors.go
@@ -95,7 +95,7 @@ func CORS(options ...Options) flamego.Handler {
 
 			var ok bool
 			for _, d := range opt.AllowDomain {
-				if u.Hostname() == d ||
+				if u.Host == d ||
 					(opt.AllowSubdomain && strings.HasSuffix(u.Hostname(), "."+d)) ||
 					d == "!*" {
 					ok = true

--- a/cors_test.go
+++ b/cors_test.go
@@ -74,6 +74,7 @@ func TestCustomCORS(t *testing.T) {
 		Scheme: "https",
 		AllowDomain: []string{
 			"example.com",
+			"example.com:8080",
 		},
 		AllowSubdomain: false,
 		Methods: []string{
@@ -127,7 +128,19 @@ func TestCustomCORS(t *testing.T) {
 			wantCode: http.StatusOK,
 		},
 		{
-			name:   "error subdomain",
+			name:   "host with port",
+			method: http.MethodOptions,
+			reqHeaders: map[string]string{
+				"Origin": "https://example.com:8080",
+			},
+			wantHeaders: map[string]string{
+				"Access-Control-Allow-Origin": "https://example.com:8080",
+			},
+			wantCode: http.StatusOK,
+		},
+
+		{
+			name:   "bad subdomain",
 			method: http.MethodOptions,
 			reqHeaders: map[string]string{
 				"Origin": "https://a.example.com",
@@ -141,7 +154,7 @@ func TestCustomCORS(t *testing.T) {
 			wantResponseBody: "CORS request from prohibited domain https://a.example.com\n",
 		},
 		{
-			name:   "error scheme",
+			name:   "bad scheme",
 			method: http.MethodOptions,
 			reqHeaders: map[string]string{
 				"Origin": "http://example.com",
@@ -154,12 +167,12 @@ func TestCustomCORS(t *testing.T) {
 			wantCode: http.StatusOK,
 		},
 		{
-			name:   "host with port",
+			name:   "bad host with port",
 			method: http.MethodOptions,
 			reqHeaders: map[string]string{
-				"Origin": "http://example.com:8080",
+				"Origin": "http://example.com:10086",
 			},
-			wantResponseBody: "CORS request from prohibited domain http://example.com:8080\n",
+			wantResponseBody: "CORS request from prohibited domain http://example.com:10086\n",
 			wantCode:         http.StatusBadRequest,
 		},
 	}

--- a/cors_test.go
+++ b/cors_test.go
@@ -153,6 +153,15 @@ func TestCustomCORS(t *testing.T) {
 			},
 			wantCode: http.StatusOK,
 		},
+		{
+			name:   "host with port",
+			method: http.MethodOptions,
+			reqHeaders: map[string]string{
+				"Origin": "http://example.com:8080",
+			},
+			wantResponseBody: "CORS request from prohibited domain http://example.com:8080\n",
+			wantCode:         http.StatusBadRequest,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Describe the pull request

The cors middleware forget to check port in `Origin` header since `URL.Hostname()` doesn't contain port information.
I changed `URL.Hostname()` to `URL.Host` and add a testing for it.

Related issue:  https://github.com/flamego/flamego/issues/116

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.


