### PR TITLE
fix: incorrect handling of non-CORS requests

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -83,7 +83,7 @@ func CORS(options ...Options) flamego.Handler {
 		} else {
 			origin := ctx.Request().Header.Get("Origin")
 			if origin == "" {
-				// request is not a CORS request
+				// Skip non-CORS requests
 				return
 			}
 

--- a/cors.go
+++ b/cors.go
@@ -83,7 +83,7 @@ func CORS(options ...Options) flamego.Handler {
 		} else {
 			origin := ctx.Request().Header.Get("Origin")
 			if origin == "" {
-				http.Error(ctx.ResponseWriter(), "Missing origin header in CORS request", http.StatusBadRequest)
+				// request is not a CORS request
 				return
 			}
 


### PR DESCRIPTION
### Describe the pull request

Fix CORS middleware will still intercept and require origin fields in the request header when encountering non-cross-domain requests.

When a non-cross-domain request is received, the request should not intercepted.

Link to the issue: fix https://github.com/flamego/flamego/issues/142

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
