### PR TITLE
chore: only set `Access-Control-Allow-Credentials` when it’s `true`

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -110,8 +110,11 @@ func CORS(options ...Options) flamego.Handler {
 				u.Scheme = opt.Scheme
 			}
 			headers["Access-Control-Allow-Origin"] = u.String()
-			headers["Access-Control-Allow-Credentials"] = strconv.FormatBool(opt.AllowCredentials)
 			headers["Vary"] = "Origin"
+
+			if opt.AllowCredentials {
+				headers["Access-Control-Allow-Credentials"] = "true"
+			}
 		}
 
 		ctx.ResponseWriter().Before(func(w flamego.ResponseWriter) {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials, `true` is the only valid value.